### PR TITLE
Suggestion of usage of highlight.js for language agnostic syntax.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,12 @@
 name: Ana Silvia
-markdown: kramdown
 url: "https://a-silvia.github.io"
-baseurl: 
+baseurl:
 
 favicon: "/img/icons/favicon.svg"
 
-highlighter: rouge
+# Editing Settings
+markdown: kramdown
+highlighter: none
 
 ############
 # Timeline #
@@ -27,5 +28,6 @@ events:
   - image: "/img/timeline/prague.png"
     date: "January 2011 - August 2011"
     description: "ERASMUS in CVUT (Prague, Czech Republic)"
+
 # First image of the Timeline
 timeline-img: "/img/timeline/before.png"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,6 +7,11 @@
 			<link rel="stylesheet" type="text/css" href="/css/base.css">
 			<!-- link to specific stylesheet -->
 			<link rel="stylesheet" type="text/css" href="/css/post.css">
+
+			<!-- highlight.js -->
+			<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/styles/default.min.css">
+			<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js"></script>
+			<script>hljs.initHighlightingOnLoad();</script>
 		</head>
 		<body>
 			<nav>
@@ -17,15 +22,15 @@
 	    		</ul>
 			</nav>
 			<div class="container">
-			
+
 			<h2>{{ page.title }}</h2>
 			<p class="post-meta">{{ page.date | date_to_string }}</p>
 
 
 			<div class="post">
 			  {{ content }}
-			</div> 
-			
+			</div>
+
 			</div>
 			{% include footer.html %}
 		</body>

--- a/_posts/2016-06-23-Jupyter-Example.md
+++ b/_posts/2016-06-23-Jupyter-Example.md
@@ -6,25 +6,25 @@ date: 2016-06-23
 The purpose of this notebook is only to experiment with integrating it into my blog. So let's run some simple python statements and see how things come together!
 
 
-{% highlight python %}
+```
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 %matplotlib inline
 import seaborn as sns
-{% endhighlight %}
+```
 
 I will load the infamous Iris dataset. I can do so from Seaborn:
 
 
-{% highlight python %}
+```
 data = sns.load_dataset('iris')
-{% endhighlight %}
+```
 
 
-{% highlight py %}
+```
 data.head()
-{% endhighlight %}
+```
 
 
 
@@ -90,8 +90,8 @@ data.head()
 Just so that I have a plot, I will make a pairplot of this dataset - essentially, a scatter plot where the axis are all the pairs of columns. The diagonal shows the distribution of each column in a histogram. The colors correspond to the species of irises in the data.
 
 
-{% highlight python %}
+```
 sns.pairplot(data, hue="species")
-{% endhighlight %}
+```
 
 <img src="/notebooks/Example_files/Example_6_1.png" class="plot">


### PR DESCRIPTION
I suggest you use the [highlight.js](https://highlightjs.org/) Javascript library. It is language agnostic, it's relatively lightweight, it's simple Javascript and can be customized both in configuration and styles.

Working version with **highlight.js** and Jekyll:
![highlightjs](https://cloud.githubusercontent.com/assets/2028058/16359913/3d9b7234-3b3f-11e6-84fe-190ae706ca68.png)
